### PR TITLE
Fix pygame initialization

### DIFF
--- a/chip8.py
+++ b/chip8.py
@@ -120,6 +120,7 @@ class Emulator:
 
         self.delayTimer = DelayTimer()
         self.soundTimer = SoundTimer()
+        pygame.init()
         pygame.time.set_timer(pygame.USEREVENT+1, int(1000 / 60))
         
         self.keys = []
@@ -154,7 +155,6 @@ class Emulator:
         self.zeroColor = [0, 0, 50]
         self.oneColor = [255, 255, 255]
 
-        pygame.init()
         self.size = 10
         width = 64
         height = 32


### PR DESCRIPTION
Looks like you're trying to set the `pygame` timer before initializing `pygame` itself.

```
python chip8.py games/Brick.ch8 
pygame 2.5.2 (SDL 2.28.2, Python 3.10.8)
Hello from the pygame community. https://www.pygame.org/contribute.html
Traceback (most recent call last):
  File "/home/master/dev/Python-CHIP8-Emulator/chip8.py", line 642, in <module>
    chip8 = Emulator()
  File "/home/master/dev/Python-CHIP8-Emulator/chip8.py", line 123, in __init__
    pygame.time.set_timer(pygame.USEREVENT+1, int(1000 / 60))
pygame.error: pygame is not initialized
```